### PR TITLE
Trigger Optimizely Experiments after the content has rendered

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -38,5 +38,11 @@ var Routes = (
  * Start router
  */
 Router.run(Routes, Router.HashLocation, (Root) => {
-  React.render(<Root />, document.body);
+  React.render(<Root />, document.body, function () {
+    // After the content is rendered we need to manually activate
+    // any Optimizely experiment running on this site
+    // https://help.optimizely.com/hc/en-us/articles/200040225#conditional
+    window.optimizely = window.optimizely || [];
+    window.optimizely.push(["activate"]);
+  });
 });


### PR DESCRIPTION
Because of the way React renders the page, we need to manually trigger any Optimizely experiments which are running _after_ the content has rendered.

Without this, Optimizely tries to modify the content before it's been pushed to the DOM.

Ref: https://help.optimizely.com/hc/en-us/articles/200040225#manual
