### PR TITLE
allow use of webmaker-core via npm link.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,10 @@
 var path = require('path');
+var fs = require('fs');
+
+var webmakerCorePath = fs.realpathSync(path.resolve(
+  __dirname,
+  'node_modules/webmaker-core'
+));
 
 module.exports = {
   entry: __dirname + '/src/main.jsx',
@@ -10,22 +16,25 @@ module.exports = {
     'react': 'React',
     'react/addons': 'React'
   },
+  // http://webpack.github.io/docs/troubleshooting.html#npm-linked-modules-doesn-t-find-their-dependencies
+  resolve: { fallback: path.join(__dirname, "node_modules") },
+  resolveLoader: { fallback: path.join(__dirname, "node_modules") },
   module: {
     loaders: [
       {
         test: /\.js$/,
         loaders: ['babel-loader'],
-        include: [path.resolve(__dirname, 'node_modules/webmaker-core/src'), path.resolve(__dirname, 'src')]
+        include: [path.join(webmakerCorePath, 'src'), path.resolve(__dirname, 'src')]
       },
       {
         test: /\.jsx$/,
         loaders: ['babel-loader', 'jsx-loader'],
-        include: [path.resolve(__dirname, 'node_modules/webmaker-core/src'), path.resolve(__dirname, 'src')]
+        include: [path.join(webmakerCorePath, 'src'), path.resolve(__dirname, 'src')]
       },
       {
         test: /\.json$/,
         loaders: ['json-loader'],
-        include: [path.resolve(__dirname, 'www_src'),  path.resolve(__dirname, 'node_modules')]
+        include: [path.join(webmakerCorePath, 'node_modules'), path.resolve(__dirname, 'www_src'),  path.resolve(__dirname, 'node_modules')]
       }
     ]
   }


### PR DESCRIPTION
this fixes #147. I also verified that things still work when _not_ using `npm link`.
