### PR TITLE
Make 'npm start' work on Windows.

### DIFF
--- a/npm_tasks/build-core.js
+++ b/npm_tasks/build-core.js
@@ -1,0 +1,21 @@
+var fs = require('fs');
+var path = require('path');
+var execSync = require('child_process').execSync;
+
+var ROOT_DIR = path.resolve(__dirname, '..');
+var WEBMAKER_CORE_DIR = fs.realpathSync(path.resolve(
+  ROOT_DIR, 'node_modules', 'webmaker-core'
+));
+
+function main() {
+  execSync('npm install', { cwd: WEBMAKER_CORE_DIR, stdio: 'inherit' });
+  execSync('node npm_tasks/copy-env.js',
+           { cwd: ROOT_DIR, stdio: 'inherit' });
+  execSync('npm run build', { cwd: WEBMAKER_CORE_DIR, stdio: 'inherit' });
+}
+
+exports.WEBMAKER_CORE_DIR = WEBMAKER_CORE_DIR;
+
+if (!module.parent) {
+  main();
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:static": "ncp ./static ./build",
     "build:css": "npm run watch:css -- --no-watch",
     "build:js": "npm run build:core && npm run config && webpack -d",
-    "build:core": "npm explore webmaker-core -- npm install && node npm_tasks/copy-env.js && npm explore webmaker-core -- npm run build",
+    "build:core": "node npm_tasks/build-core.js",
     "watch:js": "npm run build:js -- --watch",
     "watch:css": "autoless --autoprefix \"> 5%, last 2 versions, android >= 4.0\" ./src ./build/css",
     "test": "npm-run-all test:**",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,7 @@
 var path = require('path');
 
+var WEBMAKER_CORE_DIR = require('./npm_tasks/build-core').WEBMAKER_CORE_DIR;
+
 module.exports = {
   entry: __dirname + '/src/main.jsx',
   output: {
@@ -17,7 +19,7 @@ module.exports = {
         test: /\.js$/,
         loaders: ['babel-loader'],
         include: [
-          /\/webmaker-core\//,
+          WEBMAKER_CORE_DIR,
           path.resolve(__dirname, 'src')
         ]
       },
@@ -25,7 +27,7 @@ module.exports = {
         test: /\.jsx$/,
         loaders: ['babel-loader', 'jsx-loader'],
         include: [
-          /\/webmaker-core\//,
+          WEBMAKER_CORE_DIR,
           path.resolve(__dirname, 'src')
         ]
       },
@@ -33,7 +35,7 @@ module.exports = {
         test: /\.json$/,
         loaders: ['json-loader'],
         include: [
-          /\/webmaker-core\//,
+          WEBMAKER_CORE_DIR,
           path.resolve(__dirname, 'www_src'),
           path.resolve(__dirname, 'node_modules')
         ]


### PR DESCRIPTION
This fixes #151.

Note that the changes to `webpack.config.js` in #156 didn't work on Windows because the regexps assumed windows path names. Since we have to figure out the real path to `webmaker-core` anyways, I ended up just replacing the regexps with the real path.
