### PR TITLE
[#191] Redirect to 404 for projects that aren't found

### DIFF
--- a/src/locales/en-US.yaml
+++ b/src/locales/en-US.yaml
@@ -20,6 +20,7 @@ en-US:
   give_us_a_shout_sentence: "{GiveUsAShoutLink} if you think there’s something wrong."
   or_visit_teach_mozilla_org: "Or visit {LinkToTeachSite}"
   page_404: This page doesn't exist!
+  project_404: No project found at this URL!
   return_to_webmaker: Return to Webmaker
   project_title_play_page: "{ projectName } by { projectAuthor }"
   no_thanks: No, thanks

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -34,6 +34,7 @@ var Routes = (
     <Route path="/project" handler={Project} />
     <Redirect from="/player" to="/project" />
     <Route path="/legal" handler={TOS} />
+    <Route path="/project-not-found" handler={ErrorView} />
     <NotFoundRoute handler={ErrorView} />
     <DefaultRoute handler={Splash} />
   </Route>

--- a/src/pages/error/error.jsx
+++ b/src/pages/error/error.jsx
@@ -6,12 +6,17 @@ var FormattedMessage = require('react-intl').FormattedMessage;
 module.exports = React.createClass({
   mixins: [
     React.addons.LinkedStateMixin,
+    require('react-router').State,
     require('react-intl').IntlMixin
   ],
   render: function () {
     var helpLink = (<a href="mailto:help@webmaker.org">{this.getIntlMessage('give_us_a_shout')}</a>);
     var teachSiteLink = (<a href="https://teach.mozilla.org/">teach.mozilla.org</a>);
-
+    var currentPath = this.getPathname();
+    var errorMessage = this.getIntlMessage('page_404');
+    if (currentPath === '/project-not-found') {
+      errorMessage = this.getIntlMessage('project_404');
+    }
     return (
       <div id="splash" className="error">
         <Masthead/>
@@ -19,7 +24,7 @@ module.exports = React.createClass({
         <div id="mid">
           <div className="inner legal centered">
             <h1>404</h1>
-            <h2>{this.getIntlMessage('page_404')}</h2>
+            <h2>{errorMessage}</h2>
             <p>
               <FormattedMessage
                 message={this.getIntlMessage('give_us_a_shout_sentence')}

--- a/src/pages/project/project.jsx
+++ b/src/pages/project/project.jsx
@@ -9,6 +9,7 @@ var AppCta = require('../../components/app-cta/app-cta.jsx');
 
 module.exports = React.createClass({
   mixins: [
+    require('react-router').Navigation,
     require('webmaker-core/src/pages/project/transforms'),
     require('webmaker-core/src/pages/project/remix'),
     require('webmaker-core/src/pages/project/cartzoom'),
@@ -55,6 +56,10 @@ module.exports = React.createClass({
     };
 
     nets(options, (err, res, body) => {
+      if (res.statusCode === 404) {
+        return this.replaceWith('/project-not-found?user=' + this.props.query.user + '&project=' + this.props.query.project);
+      }
+
       if (err || res.statusCode !== 200) {
         return console.error('Could not fetch the page');
       }


### PR DESCRIPTION
Hey @gvn what do you think of this approach? It will change the URL to `/project-not-found` instead of `/project` if the project doesn't exist, do you think that's too weird/confusing?
