### PR TITLE
Redirect /me to teach (specified by process.env.TEACH_ME_PAGE_URL)

### DIFF
--- a/server.js
+++ b/server.js
@@ -104,6 +104,14 @@ server.route({
 
 server.route({
   method: 'GET',
+  path: '/me',
+  handler: function (request, reply) {
+    reply.redirect(process.env.TEACH_ME_PAGE_URL);
+  }
+});
+
+server.route({
+  method: 'GET',
   path: '/{path}/{param*}',
   handler: {
     directory: {

--- a/server.js
+++ b/server.js
@@ -102,12 +102,20 @@ server.route({
   }
 });
 
+var meRedirect = function (request, reply) {
+  reply.redirect(process.env.TEACH_ME_PAGE_URL);
+};
+
 server.route({
   method: 'GET',
   path: '/me',
-  handler: function (request, reply) {
-    reply.redirect(process.env.TEACH_ME_PAGE_URL);
-  }
+  handler: meRedirect
+});
+
+server.route({
+  method: 'GET',
+  path: '/{locale}/me',
+  handler: meRedirect
 });
 
 server.route({


### PR DESCRIPTION
Fixes mozilla/webmaker-core#672

@jbuck Do we want to worry about localized urls? If yes, we have a problem, since hapi 8.6.0 routing doesn't support wildcards where we'd need them to be.
